### PR TITLE
Feature get role unused service permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ pip install iamunused
 Run iamunused:
 
 ```
-iamunused
+python -m iamunused
 ```

--- a/iamunused/__init__.py
+++ b/iamunused/__init__.py
@@ -1,4 +1,4 @@
 # __init__.py
 
 # Version of the iamunused package
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/iamunused/__init__.py
+++ b/iamunused/__init__.py
@@ -1,4 +1,4 @@
 # __init__.py
 
 # Version of the iamunused package
-__version__ = "0.2.0"
+__version__ = "0.2.7"

--- a/iamunused/__main__.py
+++ b/iamunused/__main__.py
@@ -1,8 +1,9 @@
 # __main__.py
-from iamunused import reader
+from .reader import Reader
 
 def main():
-    reader.get_unused()
+    r = Reader("role", 0)
+    r.get_unused()
 
 if __name__ == "__main__":
     main()

--- a/iamunused/reader.py
+++ b/iamunused/reader.py
@@ -1,5 +1,6 @@
 # reader.py
 import boto3
+import time
 
 class Reader(object):
     def __init__(self, type, days):
@@ -7,26 +8,40 @@ class Reader(object):
         self.days = days
         self.iam = boto3.client('iam')
 
+    def get_unused(self):
+        roles = self.get_roles()
+
+        for role in roles:
+            self.get_unused_role_permissions(role)
+
+
     def get_roles(self):
         response = self.iam.list_roles()
         return response['Roles']
 
     def get_unused_role_permissions(self, role):
         unused = []
-        
-        job_id = self.iam.generate_service_last_accessed_details(
+
+        job = self.iam.generate_service_last_accessed_details(
             Arn = role['Arn'],
             Granularity = 'SERVICE_LEVEL'
         )
 
-        response = self.iam.get_service_last_accessed_details(
-            JobId = job_id['JobId']
+        services = self.iam.get_service_last_accessed_details(
+            JobId = job['JobId']
         )
 
-        for service in response['ServicesLastAccessed']:
-            if service['LastAuthenticated'] is not None:
+        while services['JobStatus'] != 'COMPLETED':
+            time.sleep(1.0)
+            services = self.iam.get_service_last_accessed_details(
+                JobId = job['JobId']
+            )
+
+        for service in services['ServicesLastAccessed']:
+            if 'LastAuthenticated' in service:
                 unused.append(service['ServiceName'])
         
+        print(f'\"{role["RoleName"]}\": {unused}')
         return unused
 
     def __exit__(self):

--- a/iamunused/reader.py
+++ b/iamunused/reader.py
@@ -1,4 +1,33 @@
 # reader.py
+import boto3
 
-def get_unused():
-    print("Coming soon...")
+class Reader(object):
+    def __init__(self, type, days):
+        self.type = type
+        self.days = days
+        self.iam = boto3.client('iam')
+
+    def get_roles(self):
+        response = self.iam.list_roles()
+        return response['Roles']
+
+    def get_unused_role_permissions(self, role):
+        unused = []
+        
+        job_id = self.iam.generate_service_last_accessed_details(
+            Arn = role['Arn'],
+            Granularity = 'SERVICE_LEVEL'
+        )
+
+        response = self.iam.get_service_last_accessed_details(
+            JobId = job_id['JobId']
+        )
+
+        for service in response['ServicesLastAccessed']:
+            if service['LastAuthenticated'] is not None:
+                unused.append(service['ServiceName'])
+        
+        return unused
+
+    def __exit__(self):
+        self.iam.close()

--- a/iamunused/test_reader.py
+++ b/iamunused/test_reader.py
@@ -15,7 +15,7 @@ class TestReader(unittest.TestCase):
 
     def test_get_unused_role_permissions(self):
         roles = self.reader.get_roles()
-        unused = self.reader.get_unused_role_permissions(roles[0])
+        unused = self.reader.get_unused_role_permissions(roles[1])
         self.assertIsNotNone(roles)
         self.assertIsNotNone(unused)
 

--- a/iamunused/test_reader.py
+++ b/iamunused/test_reader.py
@@ -1,0 +1,23 @@
+# test_reader.py
+import unittest
+from reader import Reader
+import warnings
+
+class TestReader(unittest.TestCase):
+
+    def setUp(self):
+        self.reader = Reader("role", None)
+        warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed.*<ssl.SSLSocket.*>") 
+
+    def test_get_roles(self):
+        roles = self.reader.get_roles()
+        self.assertIsNotNone(roles)
+
+    def test_get_unused_role_permissions(self):
+        roles = self.reader.get_roles()
+        unused = self.reader.get_unused_role_permissions(roles[0])
+        self.assertIsNotNone(roles)
+        self.assertIsNotNone(unused)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="iamunused",
-    version="0.1.0",
+    version="0.2.0",
     description="Scan and remediate unused permissions within IAM Policies",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -21,7 +21,7 @@ setup(
     ],
     packages=["iamunused"],
     include_package_data=True,
-    install_requires=[],
+    install_requires=["boto3", "time"],
     entry_points={
         "console_scripts": [
             "iamunused=iamunused.__main__:main",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="iamunused",
-    version="0.2.0",
+    version="0.2.7",
     description="Scan and remediate unused permissions within IAM Policies",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -21,7 +21,7 @@ setup(
     ],
     packages=["iamunused"],
     include_package_data=True,
-    install_requires=["boto3", "time"],
+    install_requires=["boto3"],
     entry_points={
         "console_scripts": [
             "iamunused=iamunused.__main__:main",

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,1 +1,0 @@
-# test_reader.py


### PR DESCRIPTION
First feature implemented.

When you run the ```iamunused``` command it cycles through all the roles in your AWS Account and checks the Services the roles have access to, returning the Services names for each role that are not being used. This highlights whole services that are not being used by the role, which is has access too; this information can be utilised to remove those permissions where required.